### PR TITLE
Add .bonial/catalog-info.yaml config file

### DIFF
--- a/.bonial/catalog-info.yaml
+++ b/.bonial/catalog-info.yaml
@@ -1,0 +1,16 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: MkRadar
+  description: Markdowns monitoring system and static site generator
+    Usually, when people changing their source code they keep forgetting to update related documents on the wiki side, also, having a well-structured wiki which we can track it easily and changing it smoothly is hard, therefore, here we are trying to find a solution for these problems.
+  annotations:
+    github.com/project-slug: Bonial-International-GmbH/MkRadar
+  tags:
+    - doc
+    - python
+    - opensource
+spec:
+  type: service
+  lifecycle: experimental
+  owner: team-devops


### PR DESCRIPTION
This pull request adds a **Backstage entity metadata file** to this repository so that the component can be added to the [Bonial Backstage software catalog](https://shared-904f02-backstage.aws-sdlc-bonial.com).

After this pull request is merged, the component will become available.

For more information, read an [overview of the Backstage software catalog](https://backstage.io/docs/features/software-catalog/software-catalog-overview).